### PR TITLE
Fix FunctionCall error

### DIFF
--- a/src/mcl/Compiler.hx
+++ b/src/mcl/Compiler.hx
@@ -557,7 +557,7 @@ class McFile {
 									resolved.push(node);
 							}
 						}
-						context.append(injectValues('function ${context.namespace}:${resolved.join("/")} ${data.length == 0 ? '' : ' $data'}', context, pos));
+						context.append(injectValues('function ${context.namespace}:${resolved.join("/")}${data.length == 0 ? '' : ' $data'}', context, pos));
 					default:
 						context.append(injectValues('function ${name}${data.length == 0 ? '' : ' $data'}', context, pos));
 				}


### PR DESCRIPTION
There is a space in one of the cases of the switch in FunctionCall, where there isn't a space in the other cases in that switch, and it was causing an issue where there would be an extra space. (Who would've thought)